### PR TITLE
Deploy to test pypi on PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,7 @@ permissions:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,0 +1,54 @@
+# this file is *not* meant to cover or endorse the use of GitHub Actions, but rather to
+# help make automated releases for this project
+
+name: Upload Python Package to test.pypi.org
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.9'
+    - name: Install build dependencies
+      run: |
+        python -m pip install -U setuptools wheel build
+        if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
+    - name: Build package
+      run: |
+        changelog2version \
+          --changelog_file changelog.md \
+          --version_file be_upy_blink/version.py \
+          --version_file_type py \
+          --additional_version_info="-rc${{ github.run_number }}.dev${{ github.event.number }}" \
+          --debug
+        python setup.py sdist
+    - name: Test built package
+      # sdist call creates non twine conform "*.orig" files, remove them
+      run: |
+        rm dist/*.orig
+        twine check dist/*.tar.gz
+    - name: Archive build package artifact
+      uses: actions/upload-artifact@v3
+      with:
+        # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+        # ${{ github.repository }} and ${{ github.ref_name }} can't be used for artifact name due to unallowed '/'
+        name: dist_repo.${{ github.event.repository.name }}_sha.${{ github.sha }}_build.${{ github.run_number }}
+        path: dist/*.tar.gz
+        retention-days: 14
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1.5
+      with:
+        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        skip_existing: true
+        verbose: true
+        print_hash: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,20 +15,13 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-    # strategy:
-    #   fail-fast: false
-    #   matrix:
-    #     python-version: ["3.8", "3.9", "3.10"]
-
     steps:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        # python-version: ${{ matrix.python-version }}
         python-version: '3.9'
     - name: Install dependencies
       run: |
@@ -49,11 +42,3 @@ jobs:
     - name: Test built package
       run: |
         twine check dist/*
-    - name: Archive build package artifact
-      uses: actions/upload-artifact@v3
-      with:
-        # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
-        # ${{ github.repository }} and ${{ github.ref_name }} can't be used for artifact name due to unallowed '/'
-        name: dist_repo.${{ github.event.repository.name }}_sha.${{ github.sha }}_build.${{ github.run_number }}
-        path: dist/*.tar.gz
-        retention-days: 14

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ MicroPython PyPi package template with GitHub Action based testing and deploy
 	- [Install required tools](#install-required-tools)
 - [Setup](#setup)
 	- [Install package with upip](#install-package-with-upip)
+		- [General](#general)
+		- [Specific version](#specific-version)
+		- [Test version](#test-version)
 	- [Manually](#manually)
 		- [Upload files to board](#upload-files-to-board)
 - [Usage](#usage)
@@ -64,12 +67,40 @@ station.connect('SSID', 'PASSWORD')
 station.isconnected()
 ```
 
-and install this lib on the MicroPython device like this
+#### General
+
+Install the latest package version of this lib on the MicroPython device
 
 ```python
 import upip
 upip.install('micropython-package-template')
 ```
+
+#### Specific version
+
+Install a specific, fixed package version of this lib on the MicroPython device
+
+```python
+import upip
+upip.install('micropython-package-template==0.1.1')
+```
+
+#### Test version
+
+Install a specific release candidate version uploaded to
+[Test Python Package Index](https://test.pypi.org/) on every PR on the
+MicroPython device. If no specific version is set, the latest stable version
+will be used.
+
+```python
+import upip
+# overwrite index_urls to only take artifacts from test.pypi.org
+upip.index_urls = ['https://test.pypi.org/pypi']
+upip.install('micropython-package-template==0.2.0rc1.dev6')
+```
+
+See also [brainelectronics Test PyPi Server in Docker][ref-brainelectronics-test-pypiserver]
+for a test PyPi server running on Docker.
 
 ### Manually
 
@@ -140,4 +171,5 @@ Based on the [PyPa sample project][ref-pypa-sample].
 
 <!-- Links -->
 [ref-remote-upy-shell]: https://github.com/dhylands/rshell
+[ref-brainelectronics-test-pypiserver]: https://github.com/brainelectronics/test-pypiserver
 [ref-pypa-sample]: https://github.com/pypa/sampleproject

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,19 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.2.0] - 2022-10-22
+### Added
+- Deploy to [Test Python Package Index](https://test.pypi.org/) on every PR
+  build with a [PEP440][ref-pep440] compliant `-rc<BUILDNUMBER>.dev<PR_NUMBER>`
+  meta data extension, see [#5][ref-issue-5]
+- [Test release workflow](.github/workflows/test-release.yaml) running only on
+  PRs is archiving and uploading built artifacts to
+  [Test Python Package Index](https://test.pypi.org/)
+
+### Changed
+- Built artifacts are no longer archived by the always running
+  [test workflow](.github/workflows/test.yaml)
+
 ## [0.1.1] - 2022-10-16
 ### Fixed
 - Move `src/be_upy_blink` to `be_upy_blink` to avoid installations into `/lib/src/be_upy_blink` on a uPy board via `upip`, see [#3][ref-issue-3]
@@ -41,11 +54,14 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - [`setup.py`](setup.py) and [`sdist_upip.py`](sdist_upip.py) file
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-package-template/compare/0.1.1...develop
+[Unreleased]: https://github.com/brainelectronics/micropython-package-template/compare/0.2.0...main
 
+[0.2.0]: https://github.com/brainelectronics/micropython-package-template/tree/0.2.0
 [0.1.1]: https://github.com/brainelectronics/micropython-package-template/tree/0.1.1
 [0.1.0]: https://github.com/brainelectronics/micropython-package-template/tree/0.1.0
 
+[ref-issue-5]: https://github.com/brainelectronics/micropython-package-template/issues/5
 [ref-issue-3]: https://github.com/brainelectronics/micropython-package-template/issues/3
 
+[ref-pep440]: https://peps.python.org/pep-0440/
 [ref-python-gitignore-template]: https://github.com/github/gitignore/blob/e5323759e387ba347a9d50f8b0ddd16502eb71d4/Python.gitignore

--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -2,4 +2,4 @@
 # Avoid fixed versions
 # # to upload package to PyPi or other package hosts
 twine>=4.0.1,<5
-changelog2version>=0.1.0,<1
+changelog2version>=0.5.0,<1


### PR DESCRIPTION
### Added
- Deploy to [Test Python Package Index](https://test.pypi.org/) on every PR build with a [PEP440](https://peps.python.org/pep-0440/) compliant `-rc<BUILDNUMBER>.dev<PR_NUMBER>` meta data extension, see #5 
- [Test release workflow](.github/workflows/test-release.yaml) running only on PRs is archiving and uploading built artifacts to [Test Python Package Index](https://test.pypi.org/)

### Changed
- Built artifacts are no longer archived by the always running [test workflow](.github/workflows/test.yaml)
