### PR TITLE
Automate tagging

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -40,6 +40,7 @@ exclude =
     __init__.py
     # example testing folder before going live
     thinking
+    .idea
     # custom scripts, not being part of the distribution
     libs_external
     sdist_upip.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,14 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
@@ -41,3 +41,16 @@ jobs:
         skip_existing: true
         verbose: true
         print_hash: true
+    - name: 'Create changelog based release'
+      uses: brainelectronics/changelog-based-release@v1
+      with:
+        # note you'll typically need to create a personal access token
+        # with permissions to create releases in the other repo
+        # or you set the "contents" permissions to "write" as in this example
+        changelog-path: changelog.md
+        tag-name-prefix: ''
+        tag-name-extension: ''
+        release-name-prefix: ''
+        release-name-extension: ''
+        draft-release: true
+        prerelease: false

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -6,14 +6,14 @@ name: Upload Python Package to test.pypi.org
 on: [pull_request]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   test-deploy:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
@@ -51,3 +51,16 @@ jobs:
         skip_existing: true
         verbose: true
         print_hash: true
+    - name: 'Create changelog based prerelease'
+      uses: brainelectronics/changelog-based-release@v1
+      with:
+        # note you'll typically need to create a personal access token
+        # with permissions to create releases in the other repo
+        # or you set the "contents" permissions to "write" as in this example
+        changelog-path: changelog.md
+        tag-name-prefix: ''
+        tag-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}'
+        release-name-prefix: ''
+        release-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}'
+        draft-release: true
+        prerelease: true

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -12,7 +12,7 @@ jobs:
   test-and-coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
       with:
         python-version: '3.9'

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ MicroPython PyPi package template with GitHub Action based testing and deploy
 	- [Manually](#manually)
 		- [Upload files to board](#upload-files-to-board)
 - [Usage](#usage)
+- [Create a PyPi \(micropython\) package](#create-a-pypi-micropython-package)
+	- [Setup](#setup-1)
+	- [Create a distribution](#create-a-distribution)
+	- [Upload to PyPi](#upload-to-pypi)
 - [Contributing](#contributing)
 	- [Unittests](#unittests)
 - [Credits](#credits)
@@ -142,6 +146,51 @@ flash_led(pin=led_pin, amount=3)
 # flash_led(pin=led_pin, amount=3, on_time=1, off_time=3)
 ```
 
+## Create a PyPi (micropython) package
+
+### Setup
+
+Install the required python package with the following command in a virtual
+environment to avoid any conflicts with other packages installed on your local
+system.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+
+pip install twine
+```
+
+### Create a distribution
+
+This module overrides distutils (also compatible with setuptools) `sdist`
+command to perform pre- and post-processing as required for MicroPython's
+upip package manager. This script is taken from
+[pfalcon's picoweb][ref-pfalcon-picoweb-sdist-upip] and updated to be PEP8
+conform.
+
+```bash
+python setup.py sdist
+```
+
+A new folder `dist` will be created. The [`sdist_upip`](sdist_upip.py) will be
+used to create everything necessary.
+
+### Upload to PyPi
+
+**Be aware: [pypi.org][ref-pypi] and [test.pypi.org][ref-test-pypi] are different**
+
+You can **NOT** login to [test.pypi.org][ref-test-pypi] with the
+[pypi.org][ref-pypi] account unless you created the same on the other. See
+[invalid auth help page of **test** pypi][ref-invalid-auth-test-pypi]
+
+For testing purposes add `--repository testpypi` to
+upload it to [test.pypi.org][ref-test-pypi]
+
+```bash
+twine upload dist/micropython-package-template-*.tar.gz -u PYPI_USERNAME -p PYPI_PASSWORD
+```
+
 ## Contributing
 
 ### Unittests
@@ -174,3 +223,7 @@ Based on the [PyPa sample project][ref-pypa-sample].
 [ref-remote-upy-shell]: https://github.com/dhylands/rshell
 [ref-brainelectronics-test-pypiserver]: https://github.com/brainelectronics/test-pypiserver
 [ref-pypa-sample]: https://github.com/pypa/sampleproject
+[ref-pfalcon-picoweb-sdist-upip]: https://github.com/pfalcon/picoweb/blob/b74428ebdde97ed1795338c13a3bdf05d71366a0/sdist_upip.py
+[ref-test-pypi]: https://test.pypi.org/
+[ref-pypi]: https://pypi.org/
+[ref-invalid-auth-test-pypi]: https://test.pypi.org/help/#invalid-auth

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,14 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.4.0] - 2023-02-20
+### Added
+- `test-release` and `release` workflows create changelog based (pre-)releases
+- Documentation for manually creating a package and uploading it to PyPi in root README
+
+### Fixed
+- All workflows use checkout v3 instead of v2
+
 ## [0.3.0] - 2022-11-03
 ### Added
 - Lint package with `flake8` with [test workflow](.github/workflows/test.yaml)
@@ -65,8 +73,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - [`setup.py`](setup.py) and [`sdist_upip.py`](sdist_upip.py) file
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-package-template/compare/0.3.0...main
+[Unreleased]: https://github.com/brainelectronics/micropython-package-template/compare/0.4.0...main
 
+[0.4.0]: https://github.com/brainelectronics/micropython-package-template/tree/0.4.0
 [0.3.0]: https://github.com/brainelectronics/micropython-package-template/tree/0.3.0
 [0.2.0]: https://github.com/brainelectronics/micropython-package-template/tree/0.2.0
 [0.1.1]: https://github.com/brainelectronics/micropython-package-template/tree/0.1.1


### PR DESCRIPTION
### Added
- `test-release` and `release` workflows create changelog based (pre-)releases
- Documentation for manually creating a package and uploading it to PyPi in root README

### Fixed
- All workflows use checkout v3 instead of v2