### PR TITLE
Add further linter files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# 4 space indentation
+[*.py]
+indent_size = 4
+
+[*.yml]
+indent_size = 2
+
+[*.{md,rst}]
+indent_size = 4
+trim_trailing_whitespace = false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
-# this file is *not* meant to cover or endorse the use of GitHub Actions, but rather to
-# help make automated releases for this project
+---
+
+# this file is *not* meant to cover or endorse the use of GitHub Actions, but
+# rather to help make automated releases for this project
 
 name: Upload Python Package
 
@@ -15,42 +17,42 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.9'
-    - name: Install build dependencies
-      run: |
-        if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
-    - name: Build package
-      run: |
-        changelog2version \
-          --changelog_file changelog.md \
-          --version_file be_upy_blink/version.py \
-          --version_file_type py \
-          --debug
-        python setup.py sdist
-        rm dist/*.orig
-      # sdist call create non conform twine files *.orig, remove them
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1.5
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        skip_existing: true
-        verbose: true
-        print_hash: true
-    - name: 'Create changelog based release'
-      uses: brainelectronics/changelog-based-release@v1
-      with:
-        # note you'll typically need to create a personal access token
-        # with permissions to create releases in the other repo
-        # or you set the "contents" permissions to "write" as in this example
-        changelog-path: changelog.md
-        tag-name-prefix: ''
-        tag-name-extension: ''
-        release-name-prefix: ''
-        release-name-extension: ''
-        draft-release: true
-        prerelease: false
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Install build dependencies
+        run: |
+          if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
+      - name: Build package
+        run: |
+          changelog2version \
+            --changelog_file changelog.md \
+            --version_file be_upy_blink/version.py \
+            --version_file_type py \
+            --debug
+          python setup.py sdist
+          rm dist/*.orig
+        # sdist call create non conform twine files *.orig, remove them
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1.5
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip_existing: true
+          verbose: true
+          print_hash: true
+      - name: 'Create changelog based release'
+        uses: brainelectronics/changelog-based-release@v1
+        with:
+          # note you'll typically need to create a personal access token
+          # with permissions to create releases in the other repo
+          # or you set the "contents" permissions to "write" as in this example
+          changelog-path: changelog.md
+          tag-name-prefix: ''
+          tag-name-extension: ''
+          release-name-prefix: ''
+          release-name-extension: ''
+          draft-release: true
+          prerelease: false

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,5 +1,7 @@
-# this file is *not* meant to cover or endorse the use of GitHub Actions, but rather to
-# help make automated releases for this project
+---
+
+# this file is *not* meant to cover or endorse the use of GitHub Actions, but
+# rather to help make automated test releases for this project
 
 name: Upload Python Package to test.pypi.org
 
@@ -12,55 +14,56 @@ jobs:
   test-deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.9'
-    - name: Install build dependencies
-      run: |
-        if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
-    - name: Build package
-      run: |
-        changelog2version \
-          --changelog_file changelog.md \
-          --version_file be_upy_blink/version.py \
-          --version_file_type py \
-          --additional_version_info="-rc${{ github.run_number }}.dev${{ github.event.number }}" \
-          --debug
-        python setup.py sdist
-    - name: Test built package
-      # sdist call creates non twine conform "*.orig" files, remove them
-      run: |
-        rm dist/*.orig
-        twine check dist/*.tar.gz
-    - name: Archive build package artifact
-      uses: actions/upload-artifact@v3
-      with:
-        # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
-        # ${{ github.repository }} and ${{ github.ref_name }} can't be used for artifact name due to unallowed '/'
-        name: dist_repo.${{ github.event.repository.name }}_sha.${{ github.sha }}_build.${{ github.run_number }}
-        path: dist/*.tar.gz
-        retention-days: 14
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1.5
-      with:
-        repository_url: https://test.pypi.org/legacy/
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        skip_existing: true
-        verbose: true
-        print_hash: true
-    - name: 'Create changelog based prerelease'
-      uses: brainelectronics/changelog-based-release@v1
-      with:
-        # note you'll typically need to create a personal access token
-        # with permissions to create releases in the other repo
-        # or you set the "contents" permissions to "write" as in this example
-        changelog-path: changelog.md
-        tag-name-prefix: ''
-        tag-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}'
-        release-name-prefix: ''
-        release-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}'
-        draft-release: true
-        prerelease: true
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Install build dependencies
+        run: |
+          if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
+      - name: Build package
+        run: |
+          changelog2version \
+            --changelog_file changelog.md \
+            --version_file be_upy_blink/version.py \
+            --version_file_type py \
+            --additional_version_info="-rc${{ github.run_number }}.dev${{ github.event.number }}" \
+            --debug
+          python setup.py sdist
+      - name: Test built package
+        # sdist call creates non twine conform "*.orig" files, remove them
+        run: |
+          rm dist/*.orig
+          twine check dist/*.tar.gz
+      - name: Archive build package artifact
+        uses: actions/upload-artifact@v3
+        with:
+          # https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+          # ${{ github.repository }} and ${{ github.ref_name }} can't be used
+          # for artifact name due to unallowed '/'
+          name: dist_repo.${{ github.event.repository.name }}_sha.${{ github.sha }}_build.${{ github.run_number }}
+          path: dist/*.tar.gz
+          retention-days: 14
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1.5
+        with:
+          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          skip_existing: true
+          verbose: true
+          print_hash: true
+      - name: 'Create changelog based prerelease'
+        uses: brainelectronics/changelog-based-release@v1
+        with:
+          # note you'll typically need to create a personal access token
+          # with permissions to create releases in the other repo
+          # or you set the "contents" permissions to "write" as in this example
+          changelog-path: changelog.md
+          tag-name-prefix: ''
+          tag-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}'
+          release-name-prefix: ''
+          release-name-extension: '-rc${{ github.run_number }}.dev${{ github.event.number }}'
+          draft-release: true
+          prerelease: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Lint with flake8
         run: |
           flake8 .
+      - name: Lint with yamllint
+        run: |
+          yamllint .
       - name: Install deploy dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+---
+
+# This workflow will install Python dependencies, run tests and lint with a
+# specific Python version
+# For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Test Python package
 
@@ -17,31 +21,31 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.9'
-    - name: Install test dependencies
-      run: |
-        pip install -r requirements-test.txt
-    - name: Lint with flake8
-      run: |
-        flake8 .
-    - name: Install deploy dependencies
-      run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
-    - name: Build package
-      run: |
-        changelog2version \
-          --changelog_file changelog.md \
-          --version_file be_upy_blink/version.py \
-          --version_file_type py \
-          --debug
-        python setup.py sdist
-        rm dist/*.orig
-    - name: Test built package
-      run: |
-        twine check dist/*
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Install test dependencies
+        run: |
+          pip install -r requirements-test.txt
+      - name: Lint with flake8
+        run: |
+          flake8 .
+      - name: Install deploy dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-deploy.txt ]; then pip install -r requirements-deploy.txt; fi
+      - name: Build package
+        run: |
+          changelog2version \
+            --changelog_file changelog.md \
+            --version_file be_upy_blink/version.py \
+            --version_file_type py \
+            --debug
+          python setup.py sdist
+          rm dist/*.orig
+      - name: Test built package
+        run: |
+          twine check dist/*

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -1,5 +1,7 @@
-# this file is *not* meant to cover or endorse the use of GitHub Actions, but rather to
-# help make automated releases for this project
+---
+
+# this file is *not* meant to cover or endorse the use of GitHub Actions, but
+# rather to help run automated tests for this project
 
 name: Unittest Python Package
 
@@ -12,24 +14,24 @@ jobs:
   test-and-coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-      with:
-        python-version: '3.9'
-    - name: Execute tests
-      run: |
-        pip install -r requirements-test.txt
-        python create_report_dirs.py
-        nose2 --config tests/unittest.cfg
-    - name: Create coverage report
-      run: |
-        coverage xml
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./reports/coverage/coverage.xml
-        flags: unittests
-        fail_ci_if_error: true
-        # path_to_write_report: ./reports/coverage/codecov_report.txt
-        verbose: true
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - name: Execute tests
+        run: |
+          pip install -r requirements-test.txt
+          python create_report_dirs.py
+          nose2 --config tests/unittest.cfg
+      - name: Create coverage report
+        run: |
+          coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./reports/coverage/coverage.xml
+          flags: unittests
+          fail_ci_if_error: true
+          # path_to_write_report: ./reports/coverage/codecov_report.txt
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-# created files based on README examples
-examples/*.c
-examples/*.h
-examples/*.py
-examples/version_info
-
 # custom, package specific ignores
 .DS_Store
 .DS_Store?
@@ -15,9 +9,6 @@ thinking/
 *.bak
 *.o
 .vagrant/
-
-# meson files under development
-untitled.meson.build
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,5 @@
+---
+
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
@@ -17,4 +19,4 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
-  - requirements: docs/requirements.txt
+    - requirements: docs/requirements.txt

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,13 @@
+---
+
+extends: default
+
+ignore:
+  - .tox
+  - .venv
+
+rules:
+  line-length:
+    level: warning
+    ignore:
+      - .github/workflows/*

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,18 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.6.0] - 2023-02-22
+### Added
+- `.editorconfig` for common editor settings, see #12
+- `.yamllint` to lint all used YAML files, see #12
+- `codecov.yaml` to specify further settings and limits for the coverage
+- `yamllint` package to the `requirements-test.txt` file
+- Run YAML linter on test workflow
+
+### Changed
+- Fixed uncovered YAML syntax issues in all workflow files
+- Removed unused files from `.gitignore` file
+
 ## [0.5.0] - 2023-02-20
 ### Added
 - `.readthedocs.yaml` definition file for ReadTheDocs, see #10
@@ -78,8 +90,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - [`setup.py`](setup.py) and [`sdist_upip.py`](sdist_upip.py) file
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-package-template/compare/0.5.0...main
+[Unreleased]: https://github.com/brainelectronics/micropython-package-template/compare/0.6.0...main
 
+[0.6.0]: https://github.com/brainelectronics/micropython-package-template/tree/0.6.0
 [0.5.0]: https://github.com/brainelectronics/micropython-package-template/tree/0.5.0
 [0.4.0]: https://github.com/brainelectronics/micropython-package-template/tree/0.4.0
 [0.3.0]: https://github.com/brainelectronics/micropython-package-template/tree/0.3.0

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,11 @@
+---
+
+codecov:
+  bot: brainelectronics
+
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+        threshold: 1%

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@
 flake8>=5.0.0,<6
 coverage>=6.4.2,<7
 nose2>=0.12.0,<1
+yamllint>=1.29,<2


### PR DESCRIPTION
### Added
- `.editorconfig` for common editor settings, see #12
- `.yamllint` to lint all used YAML files, see #12
- `codecov.yaml` to specify further settings and limits for the coverage
- `yamllint` package to the `requirements-test.txt` file
- Run YAML linter on test workflow

### Changed
- Fixed uncovered YAML syntax issues in all workflow files
- Removed unused files from `.gitignore` file
